### PR TITLE
Add missing data_description translations for tessie config flow

### DIFF
--- a/homeassistant/components/tessie/strings.json
+++ b/homeassistant/components/tessie/strings.json
@@ -14,12 +14,18 @@
         "data": {
           "access_token": "[%key:common::config_flow::data::access_token%]"
         },
+        "data_description": {
+          "access_token": "[%key:component::tessie::config::step::user::data_description::access_token%]"
+        },
         "description": "[%key:component::tessie::config::step::user::description%]",
         "title": "[%key:common::config_flow::title::reauth%]"
       },
       "user": {
         "data": {
           "access_token": "[%key:common::config_flow::data::access_token%]"
+        },
+        "data_description": {
+          "access_token": "Your Tessie API access token"
         },
         "description": "Enter your access token from {url}."
       }


### PR DESCRIPTION
## Summary
- Added missing `data_description` translations for the `access_token` field in both `user` and `reauth_confirm` config flow steps
- Required by the `config-flow` quality scale rule which mandates both `data` and `data_description` translations for all fields

## Test plan
- [x] Ran `pytest tests/components/tessie` - all 42 tests pass
- [x] Verified hassfest validation passes