### PR TITLE
Use mock_setup_entry fixture in teslemetry config flow tests

### DIFF
--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -9,9 +9,7 @@ rules:
       Multiline lambdas should be wrapped in parentheses for readability (e.g. streaming_listener).
       Use chained comparison: "if 1 < x < 100" instead of "if x > 1 and x < 100".
   config-flow: done
-  config-flow-test-coverage:
-    status: todo
-    comment: Use mock_setup_entry fixture instead of inline patch
+  config-flow-test-coverage: done
   dependency-transparency: done
   docs-actions: done
   docs-high-level-description: done

--- a/tests/components/teslemetry/test_config_flow.py
+++ b/tests/components/teslemetry/test_config_flow.py
@@ -147,6 +147,7 @@ async def test_reauth(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reauth_account_mismatch(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
@@ -170,11 +171,8 @@ async def test_reauth_account_mismatch(
     old_entry.add_to_hass(hass)
 
     # Setup the integration properly to import client credentials
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(old_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(old_entry.entry_id)
+    await hass.async_block_till_done()
 
     result = await old_entry.start_reauth_flow(hass)
 
@@ -200,10 +198,7 @@ async def test_reauth_account_mismatch(
         },
     )
 
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
-    ):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reauth_account_mismatch"
@@ -349,6 +344,7 @@ async def test_reconfigure(
 
 
 @pytest.mark.usefixtures("current_request_with_host")
+@pytest.mark.usefixtures("mock_setup_entry")
 async def test_reconfigure_account_mismatch(
     hass: HomeAssistant,
     hass_client_no_auth: ClientSessionGenerator,
@@ -373,11 +369,8 @@ async def test_reconfigure_account_mismatch(
     old_entry.add_to_hass(hass)
 
     # Setup the integration properly to import client credentials
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
-    ):
-        await hass.config_entries.async_setup(old_entry.entry_id)
-        await hass.async_block_till_done()
+    await hass.config_entries.async_setup(old_entry.entry_id)
+    await hass.async_block_till_done()
 
     client = await hass_client_no_auth()
     result = await old_entry.start_reconfigure_flow(hass)
@@ -392,10 +385,7 @@ async def test_reconfigure_account_mismatch(
     await client.get(f"/auth/external/callback?code=abcd&state={state}")
     aioclient_mock.post(TOKEN_URL, json=mock_token_response)
 
-    with patch(
-        "homeassistant.components.teslemetry.async_setup_entry", return_value=True
-    ):
-        result = await hass.config_entries.flow.async_configure(result["flow_id"])
+    result = await hass.config_entries.flow.async_configure(result["flow_id"])
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "reconfigure_account_mismatch"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->

Replace inline `with patch()` blocks with the `mock_setup_entry` fixture in `test_reauth_account_mismatch` and `test_reconfigure_account_mismatch` tests for consistency with other tests in the file.

This change addresses the `config-flow-test-coverage` quality scale rule comment and marks it as done.

## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.

  AI tools are welcome, but contributors are responsible for *fully*
  understanding the code before submitting a PR.
-->

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
