### PR TITLE
Clean up stream resources in Teslemetry config entry unloading

### DIFF
--- a/homeassistant/components/teslemetry/__init__.py
+++ b/homeassistant/components/teslemetry/__init__.py
@@ -319,7 +319,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -
 
 async def async_unload_entry(hass: HomeAssistant, entry: TeslemetryConfigEntry) -> bool:
     """Unload Teslemetry Config."""
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        # Remove stream listeners for each vehicle
+        for vehicle in entry.runtime_data.vehicles:
+            vehicle.remove_listener()
+
+        # Close the stream connection
+        if entry.runtime_data.stream:
+            entry.runtime_data.stream.close()
+
+    return unload_ok
 
 
 async def async_migrate_entry(

--- a/homeassistant/components/teslemetry/quality_scale.yaml
+++ b/homeassistant/components/teslemetry/quality_scale.yaml
@@ -26,13 +26,7 @@ rules:
   unique-config-entry: done
   # Silver
   action-exceptions: done
-  config-entry-unloading:
-    status: todo
-    comment: |
-      async_unload_entry must clean up: (1) close TeslemetryStream websocket via
-      stream.close(), (2) call remove_listener() for each vehicle to unsubscribe
-      from stream events, (3) consider using entry.async_on_unload() during setup
-      to register cleanup callbacks automatically.
+  config-entry-unloading: done
   docs-configuration-parameters: done
   docs-installation-parameters: done
   entity-unavailable: done


### PR DESCRIPTION
## Proposed change

This PR addresses the `config-entry-unloading` quality scale item for the Teslemetry integration.

The `async_unload_entry` function now properly cleans up resources when the config entry is unloaded:
- Calls `remove_listener()` for each vehicle to unsubscribe from TeslemetryStream events
- Closes the TeslemetryStream WebSocket connection via `stream.close()`

Previously, the function only unloaded platforms without cleaning up the stream connection and listeners, which could lead to resource leaks.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [x] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [x] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [x] I have followed the [development checklist][dev-checklist]
- [x] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.
- [x] Any generated code has been carefully reviewed for correctness and compliance with project standards.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
