### PR TITLE
Read Model X third-row heater state over parked Bluetooth

### DIFF
--- a/homeassistant/components/teslemetry/select.py
+++ b/homeassistant/components/teslemetry/select.py
@@ -12,11 +12,12 @@ from tesla_fleet_api.teslemetry import Vehicle
 from teslemetry_stream import TeslemetryStreamVehicle
 
 from homeassistant.components.select import SelectEntity, SelectEntityDescription
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 
 from . import TeslemetryConfigEntry
+from .ble import TeslemetryVehicleBluetoothEntity
 from .entity import (
     TeslemetryEnergyInfoEntity,
     TeslemetryRootEntity,
@@ -49,6 +50,7 @@ class TeslemetrySelectEntityDescription(SelectEntityDescription):
         ]
         | None
     ) = None
+    bluetooth_field: str | None = None
     options: list[str]
 
 
@@ -138,6 +140,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
             data.get("rear_seat_heaters") == 3
             and data.get("third_row_seats", "None") != "None"
         ),
+        bluetooth_field="seat_heater_third_row_left",
         entity_registry_enabled_default=False,
         options=[
             OFF,
@@ -158,6 +161,7 @@ VEHICLE_DESCRIPTIONS: tuple[TeslemetrySelectEntityDescription, ...] = (
             data.get("rear_seat_heaters") == 3
             and data.get("third_row_seats", "None") != "None"
         ),
+        bluetooth_field="seat_heater_third_row_right",
         entity_registry_enabled_default=False,
         options=[
             OFF,
@@ -218,7 +222,11 @@ async def async_setup_entry(
     async_add_entities(
         chain(
             (
-                TeslemetryVehiclePollingSelectEntity(
+                TeslemetryBluetoothSelectEntity(
+                    vehicle, description, entry.runtime_data.scopes
+                )
+                if vehicle.ble is not None and description.bluetooth_field is not None
+                else TeslemetryVehiclePollingSelectEntity(
                     vehicle, description, entry.runtime_data.scopes
                 )
                 if vehicle.poll
@@ -353,6 +361,50 @@ class TeslemetryStreamingSelectEntity(
     def _climate_callback(self, value: bool | None) -> None:
         """Update the value of the entity."""
         self._climate = bool(value)
+
+
+class TeslemetryBluetoothSelectEntity(
+    TeslemetryVehicleBluetoothEntity, TeslemetrySelectEntity
+):
+    """Vehicle seat select entity read over a parked climate INFO snapshot."""
+
+    _attr_current_option: str | None = None
+
+    def __init__(
+        self,
+        data: TeslemetryVehicleData,
+        description: TeslemetrySelectEntityDescription,
+        scopes: list[Scope],
+    ) -> None:
+        """Initialize the vehicle seat select entity."""
+        self.entity_description = description
+        super().__init__(data, description.key)
+        self.scoped = Scope.VEHICLE_CMDS in scopes
+
+    @override
+    async def async_added_to_hass(self) -> None:
+        """Register the parked climate INFO endpoint for the seat heater."""
+        await super().async_added_to_hass()
+        self.async_on_remove(
+            self.manager.async_on_endpoint(
+                "climate",
+                lambda ble: ble.climate_state(),
+                self._handle_endpoint,
+            )
+        )
+
+    @callback
+    def _handle_endpoint(self, value: Any, generation: int) -> None:
+        """Render the seat heater level from a climate snapshot."""
+        self._value = value
+        self._generation = generation
+        if value is not None:
+            self._climate = value.is_climate_on
+            assert self.entity_description.bluetooth_field is not None
+            level = getattr(value, self.entity_description.bluetooth_field)
+            options = self.entity_description.options
+            self._attr_current_option = options[max(0, min(level, len(options) - 1))]
+        self.async_write_ha_state()
 
 
 class TeslemetryOperationSelectEntity(TeslemetryEnergyInfoEntity, SelectEntity):

--- a/tests/components/teslemetry/test_ble.py
+++ b/tests/components/teslemetry/test_ble.py
@@ -18,7 +18,7 @@ from tesla_fleet_api.tesla.vehicle.proto.vcsec_pb2 import (
 )
 
 # pylint: disable-next=no-name-in-module
-from tesla_fleet_api.tesla.vehicle.proto.vehicle_pb2 import ClosuresState
+from tesla_fleet_api.tesla.vehicle.proto.vehicle_pb2 import ClimateState, ClosuresState
 from teslemetry_stream import Signal
 
 from homeassistant.components.lock import LockState
@@ -38,7 +38,7 @@ from homeassistant.helpers import entity_registry as er
 from homeassistant.util import dt as dt_util
 
 from . import mock_config_entry, setup_platform
-from .const import PRODUCTS
+from .const import METADATA, PRODUCTS
 
 from tests.common import MockConfigEntry, async_fire_time_changed
 
@@ -71,12 +71,14 @@ async def _setup_ble(
     connected: bool = False,
     platforms: tuple[Platform, ...] = (Platform.BINARY_SENSOR,),
     sunroof: bool = False,
+    third_row: bool = False,
 ) -> tuple[MockConfigEntry, MagicMock]:
     """Set up the given platforms for a BLE-paired vehicle.
 
     Returns the entry and the BLE client mock. The client's ``listen_*`` methods
     record the manager's broadcast callbacks so tests can feed them raw values.
-    ``sunroof`` reports the vehicle's metadata as sunroof-installed.
+    ``sunroof`` reports the vehicle's metadata as sunroof-installed; ``third_row``
+    reports it as a heated-third-row Model X.
     """
     entry = _entry_with_ble()
     entry.add_to_hass(hass)
@@ -88,6 +90,12 @@ async def _setup_ble(
     if sunroof:
         products["response"][0]["vehicle_config"]["sun_roof_installed"] = True
 
+    metadata = deepcopy(METADATA)
+    if third_row:
+        config = metadata["vehicles"][VIN]["config"]
+        config["rear_seat_heaters"] = 3
+        config["third_row_seats"] = "FoldFlatWithLatch"
+
     with (
         patch(
             "homeassistant.components.teslemetry.async_ble_device_from_address",
@@ -98,6 +106,7 @@ async def _setup_ble(
         ) as mock_parent,
         patch("homeassistant.components.teslemetry.PLATFORMS", list(platforms)),
         patch("tesla_fleet_api.teslemetry.Teslemetry.products", return_value=products),
+        patch("tesla_fleet_api.teslemetry.Teslemetry.metadata", return_value=metadata),
     ):
         mock_parent.return_value.get_private_key = AsyncMock()
         mock_parent.return_value.vehicles.createBluetooth.return_value = (
@@ -591,3 +600,118 @@ async def test_sunroof_absent_makes_no_reads(
     await hass.async_block_till_done()
 
     bluetooth.closures_state.assert_not_called()
+
+
+def _climate(left: int = 0, right: int = 0, climate_on: bool = True) -> ClimateState:
+    """Build a BLE climate snapshot with third-row heater levels."""
+    return ClimateState(
+        seat_heater_third_row_left=left,
+        seat_heater_third_row_right=right,
+        is_climate_on=climate_on,
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_third_row_reads_over_climate(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_add_listener: MagicMock,
+) -> None:
+    """A heated-third-row Model X reads its levels over one climate snapshot."""
+    _entry, bluetooth = await _setup_ble(
+        hass,
+        connected=True,
+        platforms=(Platform.COVER, Platform.SELECT),
+        third_row=True,
+    )
+    left_id = entity_registry.async_get_entity_id(
+        "select", "teslemetry", f"{VIN}-climate_state_seat_heater_third_row_left"
+    )
+    assert left_id is not None
+    assert hass.states.get(left_id).state == STATE_UNAVAILABLE
+
+    bluetooth.climate_state = AsyncMock(return_value=_climate(left=2))
+    _make_active(bluetooth, mock_add_listener)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=6))
+    await hass.async_block_till_done()
+
+    bluetooth.climate_state.assert_awaited_once()
+    bluetooth.vehicle_data.assert_not_called()
+    assert hass.states.get(left_id).state == "medium"
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_third_row_and_sunroof_read_sequentially(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_add_listener: MagicMock,
+) -> None:
+    """Two configured endpoints each read once, never as an aggregate call."""
+    _entry, bluetooth = await _setup_ble(
+        hass,
+        connected=True,
+        platforms=(Platform.COVER, Platform.SELECT),
+        sunroof=True,
+        third_row=True,
+    )
+    left_id = entity_registry.async_get_entity_id(
+        "select", "teslemetry", f"{VIN}-climate_state_seat_heater_third_row_left"
+    )
+    sunroof_id = entity_registry.async_get_entity_id(
+        "cover", "teslemetry", f"{VIN}-vehicle_state_sun_roof_state"
+    )
+
+    bluetooth.climate_state = AsyncMock(return_value=_climate(left=3))
+    bluetooth.closures_state = AsyncMock(return_value=_closures("Closed"))
+    _make_active(bluetooth, mock_add_listener)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=6))
+    await hass.async_block_till_done()
+
+    bluetooth.climate_state.assert_awaited_once()
+    bluetooth.closures_state.assert_awaited_once()
+    bluetooth.vehicle_data.assert_not_called()
+    assert hass.states.get(left_id).state == "high"
+    assert hass.states.get(sunroof_id).state == STATE_CLOSED
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_third_row_absent_no_entity(
+    hass: HomeAssistant, entity_registry: er.EntityRegistry
+) -> None:
+    """A vehicle without a heated third row has no third-row select entity."""
+    await _setup_ble(hass, platforms=(Platform.SELECT,), third_row=False)
+    assert (
+        entity_registry.async_get_entity_id(
+            "select", "teslemetry", f"{VIN}-climate_state_seat_heater_third_row_left"
+        )
+        is None
+    )
+
+
+@pytest.mark.usefixtures("entity_registry_enabled_by_default")
+async def test_third_row_link_loss_marks_unavailable(
+    hass: HomeAssistant,
+    entity_registry: er.EntityRegistry,
+    mock_add_listener: MagicMock,
+) -> None:
+    """The third-row select goes unavailable on link loss, no cloud fallback."""
+    _entry, bluetooth = await _setup_ble(
+        hass,
+        connected=True,
+        platforms=(Platform.COVER, Platform.SELECT),
+        third_row=True,
+    )
+    left_id = entity_registry.async_get_entity_id(
+        "select", "teslemetry", f"{VIN}-climate_state_seat_heater_third_row_left"
+    )
+
+    bluetooth.climate_state = AsyncMock(return_value=_climate(left=1))
+    _make_active(bluetooth, mock_add_listener)
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=6))
+    await hass.async_block_till_done()
+    assert hass.states.get(left_id).state == "low"
+
+    bluetooth.client.is_connected = False
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=12))
+    await hass.async_block_till_done()
+    assert hass.states.get(left_id).state == STATE_UNAVAILABLE


### PR DESCRIPTION
## Breaking change

## Proposed change

Reroute the two Model X third-row seat-heater selects to a parked
`climate_state()` INFO read when the vehicle is BLE paired, reusing the
sleep-aware scheduler from #981 and its second serialized endpoint (closures +
climate never issue an aggregate call). Set commands still route through the
command router. The `rear_seat_heaters == 3` and `third_row_seats != "None"`
metadata gate is preserved, with both present and absent tests.

This stacks on #981 (its base branch), the last rung of the local-Bluetooth
read series.

## Type of change

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [x] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 
- Link to developer documentation pull request: 
- Link to frontend pull request: 

## Checklist

- [ ] I understand the code I am submitting and can explain how it works.
- [x] The code change is tested and works locally.
- [x] Local tests pass. **Your PR cannot be merged unless tests pass**
- [x] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [x] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [x] Tests have been added to verify that the new code works.
- [ ] Any generated code has been carefully reviewed for correctness and compliance with project standards.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies a diff between library versions and ideally a link to the changelog/release notes is added to the PR description.

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
